### PR TITLE
Travis fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: ruby
 before_install:
-  # install aspell headers and the English dictionary
-  - sudo apt-get install --no-install-recommends libaspell-dev aspell-en
   - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-  - sh ./travis_setup.sh -p "yast2-devtools"
+  # install aspell headers and the English dictionary needeed for the check:spelling task
+  - sh ./travis_setup.sh -p "yast2-devtools libaspell-dev aspell-en"
   - rm ./travis_setup.sh
 script:
   - bundle exec rake check:spelling

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 before_install:
+  # update the broken bundler at Travis
+  # see https://github.com/bundler/bundler/issues/3558#issuecomment-171347979
+  # and https://github.com/increments/qiita-markdown/pull/24
+  - gem update bundler
   - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
   # install aspell headers and the English dictionary needeed for the check:spelling task
   - sh ./travis_setup.sh -p "yast2-devtools libaspell-dev aspell-en"


### PR DESCRIPTION
- Package metadata need to be refreshed before installing `libaspell-dev` and `aspell-en`, installed them via the `travis_setup.sh` script which calls `apt-get update` internally.
- Bundler needs to be updated, the current version at Travis is somehow broken