### PR TITLE
write known targets for submitting

### DIFF
--- a/lib/yast/tasks.rb
+++ b/lib/yast/tasks.rb
@@ -40,7 +40,9 @@ module Yast
     def self.submit_to(target, file = TARGETS_FILE)
       targets = YAML.load_file(file)
       config = targets[target]
-      raise "Not configuration found for #{target}" if config.nil?
+      if config.nil?
+        raise "No configuration found for #{target}. Known values: #{targets.keys.join(", ")}"
+      end
       Yast::Tasks.configuration do |conf|
         config.each do |meth, val|
           conf.public_send("#{meth}=", val)


### PR DESCRIPTION
how it looks now:

```
jreidinger@linux-vvcf:~/prace/yast/ruby-bindings> YAST_SUBMIT=leap42_2 rake osc:build
rake aborted!
No configuration found for leap42_2. Known values: sle12, leap_42_1, leap_42_2, sle12sp1, sle12sp1_public, sle12sp2, sle12sp2_public, casp10, sle12sp3, sle_latest, factory
```