### PR TITLE
[WIP] Sort the tests to have reproducible test runs?

### DIFF
--- a/lib/tasks/test_unit.rake
+++ b/lib/tasks/test_unit.rake
@@ -2,6 +2,8 @@ namespace :test do
   desc "Runs unit tests."
   task "unit" do
     files = Dir["**/test/**/*_{spec,test}.rb"]
+    # sort the files to have reproducible runs
+    files.sort!
     sh "rspec --color --format doc '#{files.join("' '")}'" unless files.empty?
   end
 end


### PR DESCRIPTION
The very same package (same SHA sum!) builds in the IBS ([example log](https://build.suse.de/package/live_build_log/Devel:YaST:Head/yast2-installation/SUSE_SLE-15_GA/x86_64)), but fails in OBS in the tests ([example log](https://build.opensuse.org/package/live_build_log/YaST:Head/yast2-installation/openSUSE_Tumbleweed/x86_64)).

It turned out that the difference is the order of the testing files passed to rspec. Because the order is unspecified the tests are loaded in the order in which they are stored on the disk. Which means it is basically random.

This is very tricky to debug, even in the very same enviroment but with a different filesystem the result might be completely different.

Ideally the tests should be idempotent and it should not depend on the order. But this is difficult to achieve, esp. when there are hundreds of tests. And we cannot test every possible test permutations.

So the question is: **Do we prefer more reliable reproducible runs or is it better to have more or less random order which might randomly break but helps to reveal possible issues in the tests?**