### PR TITLE
Fix build for distros with more than one ruby interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rake-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 --privileged -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-rake-image yast-travis-ruby

--- a/package/rubygem-yast-rake.changes
+++ b/package/rubygem-yast-rake.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 28 15:14:13 UTC 2020 - Dominique Leuenberger <dimstar@opensuse.org>
+
+- Only build gems for the default ruby version (boo#1169445).
+
+-------------------------------------------------------------------
 Wed Feb  5 08:32:16 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "rake server" task (bsc#1162826)

--- a/package/rubygem-yast-rake.spec
+++ b/package/rubygem-yast-rake.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package rubygem-yast-rake
 #
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2020 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -12,9 +12,13 @@
 # license that conforms to the Open Source Definition (Version 1.9)
 # published by the Open Source Initiative.
 
-# Please submit bugfixes or comments via http://bugs.opensuse.org/
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
+# Only build for the default-ruby version
+%define rb_build_versions     %{rb_default_ruby}
+%define rb_build_ruby_abis    %{rb_default_ruby_abi}
 
 Name:           rubygem-yast-rake
 Version:        0.2.37
@@ -22,13 +26,13 @@ Release:        0
 %define mod_name yast-rake
 %define mod_full_name %{mod_name}-%{version}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  rubygem(%{rb_default_ruby_abi}:gem2rpm)
 BuildRequires:  %{ruby}
 BuildRequires:  ruby-macros >= 5
-Url:            http://github.org/openSUSE/yast-rake
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:gem2rpm)
+URL:            http://github.org/openSUSE/yast-rake
 Source:         http://rubygems.org/gems/%{mod_full_name}.gem
 Summary:        Rake tasks providing basic work-flow for Yast development
-License:        LGPL-2.1
+License:        LGPL-2.1-only
 Group:          Development/Languages/Ruby
 
 %description


### PR DESCRIPTION
In most of the openSUSE Distros, we carry only one ruby interpreter.
openSUSE Tumbleweed is special though; as a rolling distro it often
tries to accomodate users to changes. It's planned to add ruby 2.7 soon
(the interpreter is already present) and enable rubygems to build
for ruby 2.6 and 2.7 and later disable 2.6.

For yast, it does not make sense to provided gems for both versions and
we just build for the distro defined default version.